### PR TITLE
Fix development dependency on ActiveSupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,9 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (3.2.7)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
     crack (0.1.6)
     diff-lcs (1.1.2)
     fakeweb (1.2.8)
@@ -15,7 +18,9 @@ GEM
       libxml-ruby (~> 1.1.3)
     httparty (0.5.2)
       crack (= 0.1.6)
+    i18n (0.6.0)
     libxml-ruby (1.1.4)
+    multi_json (1.3.6)
     rspec (2.0.0.beta.22)
       rspec-core (= 2.0.0.beta.22)
       rspec-expectations (= 2.0.0.beta.22)
@@ -31,6 +36,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 3.0)
   bundler (>= 1.0.0)
   fakeweb (~> 1.2.5)
   happymapper (~> 0.3.2)

--- a/petfinder.gemspec
+++ b/petfinder.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 2.0.pre"
   s.add_development_dependency "fakeweb", "~> 1.2.5"
   s.add_development_dependency "bundler", ">= 1.0.0"
+  s.add_development_dependency "activesupport", "~> 3.0"
 
   # Standard setup that should not need modification
   s.required_rubygems_version = ">= 1.3.6"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rubygems'
 require 'petfinder'
 require 'rspec'
 require 'fakeweb'
+require 'active_support/core_ext/object/blank'
 
 def fixture_file(filename)
   File.read(File.dirname(__FILE__) + "/fixtures/#{filename}")


### PR DESCRIPTION
Otherwise, the specs fail with no method error for `blank?` which is added by `active_support/core_ext/object/blank`.
